### PR TITLE
CODEOWNERS file added

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Order matters
+# below ones takes precedence over the upper ones
+
+# global owner
+*           @nazar-pc
+
+# backend - Serge
+/backend/   @isSerge
+
+# frontend - Leo
+/frontend/  @1devNdogs


### PR DESCRIPTION
If you are unfamiliar with how Codeowners file works, please read the below explanations:

1- codeowners file is per repository (will add one to the relayer repo as the next step)
2- we are matching files or folders to the people, and the below matches take precedence over the upper ones. In other words, if I match Nazar with everything, and Serge with `backend` folder, Nazar will not get assigned to the pull requests related to `backend`.
3- To my knowledge, Jeremiah and Nazar are subscribed to all the pull-requests in this repo, so no need to include them in every match statement.

Please review this small file. If any change is required, do let me know :)